### PR TITLE
feat: support hashtags

### DIFF
--- a/src/Facets/DefaultFacetsResolver.php
+++ b/src/Facets/DefaultFacetsResolver.php
@@ -17,7 +17,7 @@ final class DefaultFacetsResolver implements FacetsResolver
         return [
             ...self::detectMentions($text, $bluesky->getClient()),
             ...self::detectLinks($text),
-            ...self::detectTags($text)
+            ...self::detectTags($text),
         ];
     }
 
@@ -77,13 +77,14 @@ final class DefaultFacetsResolver implements FacetsResolver
 
         preg_match_all($tagRegexp, $text, $matches, \PREG_OFFSET_CAPTURE);
 
-
         return array_filter(array_map(function (array $match) {
             [$tag, $position] = $match;
 
-            $tag = preg_replace("/\\p{P}+$/u", "", $tag);
+            $tag = preg_replace('/\\p{P}+$/u', '', $tag);
 
-            if(strlen($tag) > 66) {return null;}
+            if (\strlen($tag) > 66) {
+                return null;
+            }
 
             return new Facet(
                 range: [

--- a/src/Facets/Tag.php
+++ b/src/Facets/Tag.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NotificationChannels\Bluesky\Facets;
+
+final class Tag extends Feature
+{
+    public function __construct(
+        public readonly string $tag,
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return 'app.bsky.richtext.facet#tag';
+    }
+}

--- a/tests/DefaultFacetsResolverTest.php
+++ b/tests/DefaultFacetsResolverTest.php
@@ -123,14 +123,13 @@ it('detects multiple facets', function () {
     );
 });
 
-it('detects tags', function (string $text, array $positions, string $tag){
-     /** @var FacetsResolver */
+it('detects tags', function (string $text, array $positions, string $tag) {
+    /** @var FacetsResolver */
     $resolver = resolve(FacetsResolver::class);
     $facets = $resolver->resolve(
         bluesky: resolve(BlueskyService::class),
         post: BlueskyPost::make()->text($text),
     );
-
 
     expect($facets)->sequence(
         fn (Expectation $facet) => $facet->toArray()->toBe([
@@ -151,11 +150,11 @@ it('detects tags', function (string $text, array $positions, string $tag){
     ['A post with a #tag inline', [14, 18], 'tag'],
     ['#tag starting the post', [0, 4], 'tag'],
     ['a post ended by a #tag', [18, 22], 'tag'],
-    ['a tag that ends #with! punctuation',[16,21], 'with'],
+    ['a tag that ends #with! punctuation', [16, 21], 'with'],
     ['a post with #anextremelylongtagwhichisjustunderblueskys64charactertaglimit!', [12, 74], 'anextremelylongtagwhichisjustunderblueskys64charactertaglimit'],
 ]);
 
-it('doesnt detect non tags', function(string $text) {
+it('doesnt detect non tags', function (string $text) {
     /** @var FacetsResolver */
     $resolver = resolve(FacetsResolver::class);
     $facets = $resolver->resolve(
@@ -165,13 +164,12 @@ it('doesnt detect non tags', function(string $text) {
 
     expect($facets)->toBe([]);
 })->with([
-        ['A real#tag must start with space'],
-        ['a #1tag can not have a number'],
-        ['an #anextremelylongtagwhichisabsolutlyoverblueskys64charactertaglimitisnotaddedasatag'],
-    ]);
+    ['A real#tag must start with space'],
+    ['a #1tag can not have a number'],
+    ['an #anextremelylongtagwhichisabsolutlyoverblueskys64charactertaglimitisnotaddedasatag'],
+]);
 
 it('detects multiple tags', function () {
-
     /** @var FacetsResolver */
     $resolver = resolve(FacetsResolver::class);
     $facets = $resolver->resolve(


### PR DESCRIPTION
Bluesky posts made by these notifications weren't linking the hashtags as it seems this is another client side requirement.

So I've added a new detector in the defaultResolver to find and extract the tags.

It's based on the code style of the existing mention and links resolver, and aims to follow the guidlines and example from the [bluesky docs](https://docs.bsky.app/docs/advanced-guides/post-richtext).

A range of tests is included to confirm it works as expected, and with the expectation that over time more examples that should or shouldn't be found as tagged will need to be added and the regex updated where this can show what is and isn't desired.

I have confirmed this works as expected with my own account, posting with several hashtags that all were linked as expected.

