### PR TITLE
feat: add `embedUrl` to `BlueskyPost`

### DIFF
--- a/src/BlueskyPost.php
+++ b/src/BlueskyPost.php
@@ -23,6 +23,7 @@ class BlueskyPost
         public array $facets = [],
         public ?Embed $embed = null,
         public array $languages = [],
+        public ?string $embedUrl = null,
     ) {
     }
 
@@ -131,6 +132,16 @@ class BlueskyPost
     public function text(?string $text): static
     {
         $this->text = $text ?? '';
+
+        return $this;
+    }
+
+    /**
+     * Sets the URL to be resolved as an embed.
+     */
+    public function embedUrl(string $embedUrl): static
+    {
+        $this->embedUrl = $embedUrl;
 
         return $this;
     }

--- a/src/BlueskyService.php
+++ b/src/BlueskyService.php
@@ -2,6 +2,7 @@
 
 namespace NotificationChannels\Bluesky;
 
+use NotificationChannels\Bluesky\Embeds\Embed;
 use NotificationChannels\Bluesky\Embeds\EmbedResolver;
 use NotificationChannels\Bluesky\Facets\FacetsResolver;
 use NotificationChannels\Bluesky\IdentityRepository\IdentityRepository;
@@ -43,22 +44,22 @@ final class BlueskyService
             $post->facets(facets: $this->facetsResolver->resolve($this, $post));
         }
 
-        // Embeds depends on facets, so they must be resolved after
-        $embed = null;
-
-        // At first try to resolve an embed using the given URL
-        if ($post->embedUrl) {
-            $embed = $this->embedResolver->createEmbedFromUrl($this, $post->embedUrl);
-        }
-
-        // Then try to resolve embeds using links provided in the post's text
-        if (\is_null($embed) && $post->automaticallyResolvesEmbeds()) {
-            $embed = $this->embedResolver->resolve($this, $post);
-        }
-
-        $post->embed(embed: $embed);
+        $post->embed($this->resolveEmbed($post));
 
         return $post;
+    }
+
+    private function resolveEmbed(BlueskyPost $post): ?Embed
+    {
+        if ($post->embedUrl) {
+            return $this->embedResolver->createEmbedFromUrl($this, $post->embedUrl);
+        }
+        
+        if ($post->automaticallyResolvesEmbeds()) {
+            return $this->embedResolver->resolve($this, $post);
+        }
+    
+        return null;
     }
 
     public function getClient(): BlueskyClient

--- a/src/BlueskyService.php
+++ b/src/BlueskyService.php
@@ -44,9 +44,19 @@ final class BlueskyService
         }
 
         // Embeds depends on facets, so they must be resolved after
-        if ($post->automaticallyResolvesEmbeds()) {
-            $post->embed(embed: $this->embedResolver->resolve($this, $post));
+        $embed = null;
+
+        // At first try to resolve an embed using the given URL
+        if ($post->embedUrl) {
+            $embed = $this->embedResolver->createEmbedFromUrl($this, $post->embedUrl);
         }
+
+        // Then try to resolve embeds using links provided in the post's text
+        if (\is_null($embed) && $post->automaticallyResolvesEmbeds()) {
+            $embed = $this->embedResolver->resolve($this, $post);
+        }
+
+        $post->embed(embed: $embed);
 
         return $post;
     }

--- a/src/Embeds/EmbedResolver.php
+++ b/src/Embeds/EmbedResolver.php
@@ -11,4 +11,9 @@ interface EmbedResolver
      * Resolves an embed from the given post.
      */
     public function resolve(BlueskyService $bluesky, BlueskyPost $post): ?Embed;
+
+    /**
+     * Create an embed from the given URL.
+     */
+    public function createEmbedFromUrl(BlueskyService $bluesky, string $url): ?Embed;
 }

--- a/src/Embeds/LinkEmbedResolverUsingCardyb.php
+++ b/src/Embeds/LinkEmbedResolverUsingCardyb.php
@@ -29,8 +29,13 @@ final class LinkEmbedResolverUsingCardyb implements EmbedResolver
             return null;
         }
 
+        return $this->createEmbedFromUrl($bluesky, $firstLink->getFeatures()[0]->uri);
+    }
+
+    public function createEmbedFromUrl(BlueskyService $bluesky, string $url): ?Embed
+    {
         $embed = Http::get(self::ENDPOINT, [
-            'url' => $firstLink->getFeatures()[0]->uri,
+            'url' => $url,
         ]);
 
         if ($embed->json('error')) {

--- a/tests/BlueskyPostTest.php
+++ b/tests/BlueskyPostTest.php
@@ -77,3 +77,9 @@ it('has an accessble `facets` property', function () {
 
     expect($post->facets)->toBe([]);
 });
+
+it('has an accessble `embedUrl` property', function () {
+    $post = BlueskyPost::make()->text('foo')->embedUrl('https://bsky.app');
+
+    expect($post->embedUrl)->toBe('https://bsky.app');
+});


### PR DESCRIPTION
This PR implements a new feature - the ability to create an embed based on a URL that is not in the post content, but is provided separately. The URL is passed via the `embedUrl` attribute. If URLs are in both the post body and the `embedURL` attribute, the one passed via the `embedURL` attribute takes precedence.

Example:

```php
public function toBluesky(object $notifiable): BlueskyPost
{
    return BlueskyPost::make()
        ->text('Test from Laravel')
        ->embedUrl('https://innocenzi.dev');
}
```

Closes #4 