### PR TITLE
Implement blob size limit

### DIFF
--- a/src/BlueskyClient.php
+++ b/src/BlueskyClient.php
@@ -20,6 +20,7 @@ final class BlueskyClient
     public const CREATE_RECORD_ENDPOINT = 'com.atproto.repo.createRecord';
     public const UPLOAD_BLOB_ENDPOINT = 'com.atproto.repo.uploadBlob';
     public const RESOLVE_HANDLE_ENDPOINT = 'com.atproto.identity.resolveHandle';
+    public const BLOB_SIZE_LIMIT = 1_000_000;
 
     public function __construct(
         protected readonly HttpClient $httpClient,
@@ -100,7 +101,7 @@ final class BlueskyClient
         return $response->json('uri');
     }
 
-    public function uploadBlob(BlueskyIdentity $identity, string $pathOrUrl): Blob
+    public function uploadBlob(BlueskyIdentity $identity, string $pathOrUrl): ?Blob
     {
         $content = null;
 
@@ -116,6 +117,10 @@ final class BlueskyClient
 
         if (!$content) {
             throw CouldNotUploadBlob::couldNotLoadImage();
+        }
+
+        if (strlen($content) > self::BLOB_SIZE_LIMIT) {
+            return null;
         }
 
         $response = $this->httpClient

--- a/src/BlueskyService.php
+++ b/src/BlueskyService.php
@@ -26,7 +26,7 @@ final class BlueskyService
         );
     }
 
-    public function uploadBlob(string $pathOrUrl): Blob
+    public function uploadBlob(string $pathOrUrl): ?Blob
     {
         return $this->client->uploadBlob(
             identity: $this->sessionManager->getIdentity(),
@@ -54,11 +54,11 @@ final class BlueskyService
         if ($post->embedUrl) {
             return $this->embedResolver->createEmbedFromUrl($this, $post->embedUrl);
         }
-        
+
         if ($post->automaticallyResolvesEmbeds()) {
             return $this->embedResolver->resolve($this, $post);
         }
-    
+
         return null;
     }
 

--- a/src/Embeds/LinkEmbedResolverUsingCardyb.php
+++ b/src/Embeds/LinkEmbedResolverUsingCardyb.php
@@ -42,13 +42,13 @@ final class LinkEmbedResolverUsingCardyb implements EmbedResolver
             return null;
         }
 
+        $thumbnail = $bluesky->uploadBlob($embed->json('image'));
+
         return new External(
             uri: $embed->json('url'),
             title: $embed->json('title'),
             description: $embed->json('description'),
-            thumb: $bluesky
-                ->uploadBlob($embed->json('image'))
-                ->toArray(),
+            thumb: !\is_null($thumbnail) ? $thumbnail->toArray() : null,
         );
     }
 }


### PR DESCRIPTION
There is a [blob size limit (one million bytes)](https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/images.json#L24) (see also bluesky-social/atproto#1740). If you try to send a larger blob, an error message is returned:

> Could not create post (400, BlobTooLarge: This file is too large. It is [...] but the maximum size is 976.56KB.)

This PR implements a check of the size of the file being sent and if it exceeds the limit, the blob is not sent and the embed does not have a thumbnail.