### PR TITLE
fix: prevent manual embeds from being overriden

### DIFF
--- a/src/BlueskyService.php
+++ b/src/BlueskyService.php
@@ -44,7 +44,9 @@ final class BlueskyService
             $post->facets(facets: $this->facetsResolver->resolve($this, $post));
         }
 
-        $post->embed($this->resolveEmbed($post));
+        if ($embed = $this->resolveEmbed($post)) {
+            $post->embed(embed: $embed);
+        }
 
         return $post;
     }
@@ -54,11 +56,11 @@ final class BlueskyService
         if ($post->embedUrl) {
             return $this->embedResolver->createEmbedFromUrl($this, $post->embedUrl);
         }
-        
+
         if ($post->automaticallyResolvesEmbeds()) {
             return $this->embedResolver->resolve($this, $post);
         }
-    
+
         return null;
     }
 

--- a/tests/BlueskyServiceTest.php
+++ b/tests/BlueskyServiceTest.php
@@ -52,7 +52,7 @@ test('it can upload a blob', function () {
     ]);
 })->skip('Needs updating');
 
-test('the embed specified in the post is used', function () {
+test('the embed url specified in the post is resolved', function () {
     HttpResponsesFactory::fake([
         LinkEmbedResolverUsingCardyb::ENDPOINT => [
             'error' => '',
@@ -73,4 +73,19 @@ test('the embed specified in the post is used', function () {
     expect($post->embed)
         ->toBeInstanceOf(External::class)
         ->title->toBe('Google');
+});
+
+test('the embed specified in the post is used', function () {
+    $post = BlueskyPost::make()
+        ->withoutAutomaticEmbeds()
+        ->embed(new External('https://foo.fr', 'Foo', 'Bar'));
+
+    /** @var BlueskyService */
+    $service = resolve(BlueskyService::class);
+    $service->resolvePost($post);
+
+    expect($post->embed)
+        ->toBeInstanceOf(External::class)
+        ->uri->toBe('https://foo.fr')
+        ->title->toBe('Foo');
 });


### PR DESCRIPTION
A previous PR caused any manual embed to be reset to null.

This change first checks if an automatic or "embedUrl" exists before setting the embed. 
Allowing users to manually add embeds again.

You can see the change here:
https://github.com/innocenzi/bluesky-notification-channel/pull/6/files#diff-c6d67577898959a4d37d71c858957d36e5878c252b1f1f221371cd62c31ee322R47

Related Issue:
https://github.com/innocenzi/bluesky-notification-channel/issues/4